### PR TITLE
Add env example and enable Open WebUI auth

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-DOMAIN=olama.duckdns.org

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Domain for Nginx reverse proxy
+DOMAIN=example.com
+
+# Enable authentication in Open WebUI
+WEBUI_AUTH=true
+
+# Admin credentials for Open WebUI
+WEBUI_ADMIN_EMAIL=admin@example.com
+WEBUI_ADMIN_PASSWORD=changeme
+
+# Secret key for session cookies
+WEBUI_SECRET_KEY=your-secret-key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,8 +68,10 @@ services:
     environment:
       - OLLAMA_BASE_URLS=http://ollama:11434
       - ENV=dev
-      - WEBUI_AUTH=False
-      - WEBUI_SECRET_KEY=t0p-s3cr3t
+      - WEBUI_AUTH=${WEBUI_AUTH:-True}
+      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
+      - WEBUI_ADMIN_EMAIL=${WEBUI_ADMIN_EMAIL:-admin@example.com}
+      - WEBUI_ADMIN_PASSWORD=${WEBUI_ADMIN_PASSWORD:-changeme}
     ports:
       - "8181:8080"
     volumes:


### PR DESCRIPTION
## Summary
- move runtime secrets to `.env.example`
- enable authentication on Open WebUI
- read admin credentials and secret key from the environment
- stop tracking `.env`

## Testing
- `docker compose config` *(fails: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6865d2d078e0832e9b948272d8c1ae1b